### PR TITLE
Dracut kmoddir

### DIFF
--- a/cut_cephfs.sh
+++ b/cut_cephfs.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_cephfs.sh
+++ b/cut_cephfs.sh
@@ -30,7 +30,7 @@ dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 	--include "$RAPIDO_DIR/cephfs_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--add-drivers "ceph libceph e1000" \
+	--add-drivers "ceph libceph" \
 	--modules "bash base network ifcfg" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut_cephfs.sh
+++ b/cut_cephfs.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs /lib64/libkeyutils.so.1 \
 		   which perl awk bc touch cut chmod true false \
 		   fio getfattr setfattr chacl attr killall sync \
@@ -31,8 +30,7 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/cephfs_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--add-drivers "ceph libceph e1000" \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_cephfs_fuse.sh
+++ b/cut_cephfs_fuse.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_cephfs_fuse.sh
+++ b/cut_cephfs_fuse.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs /lib64/libkeyutils.so.1 \
 		   which perl awk bc touch cut chmod true false \
 		   fio getfattr setfattr chacl attr killall sync \
@@ -33,8 +32,7 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/cephfs_fuse_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--add-drivers "fuse e1000" \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_cephfs_fuse.sh
+++ b/cut_cephfs_fuse.sh
@@ -32,7 +32,7 @@ dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 	--include "$RAPIDO_DIR/cephfs_fuse_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--add-drivers "fuse e1000" \
+	--add-drivers "fuse" \
 	--modules "bash base network ifcfg" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut_cifs.sh
+++ b/cut_cifs.sh
@@ -15,9 +15,9 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs /lib64/libkeyutils.so.1 \
 		   which perl awk bc touch cut chmod true false \
 		   mktemp getfattr setfattr chacl attr killall \
@@ -30,8 +30,7 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/cifs_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--add-drivers "cifs" \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_dropbear.sh
+++ b/cut_dropbear.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1 dropbear chmod" \
 	--include "$RAPIDO_DIR/dropbear_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_fstests_cephfs.sh
+++ b/cut_fstests_cephfs.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_fstests_cephfs.sh
+++ b/cut_fstests_cephfs.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs /lib64/libkeyutils.so.1 \
 		   which perl awk bc touch cut chmod true false \
 		   mktemp getfattr setfattr chacl attr killall \
@@ -35,7 +34,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/fstests_cephfs_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_fstests_local.sh
+++ b/cut_fstests_local.sh
@@ -15,9 +15,9 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.btrfs mkfs.xfs /lib64/libkeyutils.so.1 \
 		   which perl awk bc touch cut chmod true false \
 		   mktemp getfattr setfattr chacl attr killall \
@@ -31,8 +31,7 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/fstest_local_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--add-drivers "zram lzo" \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_lio_local.sh
+++ b/cut_lio_local.sh
@@ -15,9 +15,9 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs truncate losetup dmsetup \
 		   /usr/lib/udev/rules.d/95-dm-notify.rules" \
 	--include "$RAPIDO_DIR/lio_local_autorun.sh" "/.profile" \
@@ -25,7 +25,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
 		       target_core_file dm-delay loop" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_lio_rbd.sh
+++ b/cut_lio_rbd.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
@@ -29,7 +28,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_lio_rbd.sh
+++ b/cut_lio_rbd.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_nvme_local.sh
+++ b/cut_nvme_local.sh
@@ -15,15 +15,14 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1" \
 	--include "$RAPIDO_DIR/nvme_local_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_nvme_rbd.sh
+++ b/cut_nvme_rbd.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
@@ -29,7 +28,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_nvme_rbd.sh
+++ b/cut_nvme_rbd.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_nvme_rdma.sh
+++ b/cut_nvme_rdma.sh
@@ -15,9 +15,9 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1 killall nvme" \
 	--include "$RAPIDO_DIR/nvme_rdma_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
@@ -25,7 +25,6 @@ dracut --no-compress  --kver "$KVER" \
 	--kmoddir "$KERNEL_SRC/mods" \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo ib_core ib_uverbs rdma_ucm" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_nvme_rdma.sh
+++ b/cut_nvme_rdma.sh
@@ -22,7 +22,6 @@ dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 	--include "$RAPIDO_DIR/nvme_rdma_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--kmoddir "$KERNEL_SRC/mods" \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo ib_core ib_uverbs rdma_ucm" \
 	--modules "bash base network ifcfg" \

--- a/cut_qemu_rbd.sh
+++ b/cut_qemu_rbd.sh
@@ -15,16 +15,15 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+_rt_require_dracut_args
+
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1 lsscsi" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/.profile" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT
 
 # set qemu arguments to attach the RBD image. qemu uses librbd, and supports
 # writeback caching via a "cache=writeback" parameter.

--- a/cut_rbd.sh
+++ b/cut_rbd.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_rbd.sh
+++ b/cut_rbd.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs /lib64/libkeyutils.so.1" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
@@ -28,7 +27,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RAPIDO_DIR/rbd_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_tcmu_rbd_loop.sh
+++ b/cut_tcmu_rbd_loop.sh
@@ -15,15 +15,15 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_dracut_args
+
 [ -n "$TCMU_RUNNER_SRC" ] || _fail "TCMU_RUNNER_SRC needs to be configured"
 tcmu_so_inc=""
 for i in `find ${TCMU_RUNNER_SRC} -type f|grep "\.so"`; do
 	tcmu_so_inc="${tcmu_so_inc} --include $i /lib64/`basename $i`"
 done
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep \
 		   /lib64/libkeyutils.so.1 \
 		   /usr/lib64/libnl-genl-3.so /usr/lib64/libgio-2.0.so \
@@ -43,7 +43,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "${TCMU_RUNNER_SRC}/tcmu-runner" "/bin/tcmu-runner" \
 	$tcmu_so_inc \
 	--add-drivers "target_core_mod target_core_user tcm_loop" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/cut_usb_rbd.sh
+++ b/cut_usb_rbd.sh
@@ -15,6 +15,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_ceph
+
 KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
 dracut --no-compress  --kver "$KVER" \
 	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut_usb_rbd.sh
+++ b/cut_usb_rbd.sh
@@ -16,10 +16,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
+_rt_require_dracut_args
 
-KVER="`cat ${KERNEL_SRC}/include/config/kernel.release`" || exit 1
-dracut --no-compress  --kver "$KVER" \
-	--install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   eject strace mkfs.vfat mountpoint /lib64/libkeyutils.so.1 \
 		   mktemp touch sync cryptsetup dmsetup scp ssh \
 		   /usr/lib/udev/rules.d/10-dm.rules \
@@ -38,7 +37,6 @@ dracut --no-compress  --kver "$KVER" \
 	--include "$RBD_USB_SRC/rbd-usb.conf" "/etc/rbd-usb/rbd-usb.conf" \
 	--add-drivers "target_core_mod target_core_iblock usb_f_tcm \
 		       usb_f_mass_storage zram dm-crypt" \
-	--no-hostonly --no-hostonly-cmdline \
 	--modules "bash base network ifcfg" \
-	--tmpdir "$RAPIDO_DIR/initrds/" \
-	--force $DRACUT_OUT
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -5,6 +5,13 @@
 # e.g. KERNEL_SRC="/home/me/linux"
 KERNEL_SRC=""
 
+# If specified, this parameter defines the path that Dracut should use to
+# obtain compiled kernel modules. If left blank, Dracut will use its default
+# (e.g. /lib/modules) search path.
+# A value of "${KERNEL_SRC}/mods" makes sense when used alongside
+# "INSTALL_MOD_PATH=./mods make modules_install" during kernel compilation.
+KERNEL_INSTALL_MOD_PATH="${KERNEL_SRC}/mods"
+
 # bridge device provisioned by br_setup.sh
 # e.g. BR_DEV="br0"
 BR_DEV="br0"

--- a/runtime.vars
+++ b/runtime.vars
@@ -1,5 +1,5 @@
 #
-# Copyright (C) SUSE LINUX GmbH 2016, all rights reserved.
+# Copyright (C) SUSE LINUX GmbH 2016-2017, all rights reserved.
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published
@@ -20,21 +20,7 @@ function _fail() {
 . ${RAPIDO_DIR}/rapido.conf \
 	|| _fail "rapido.conf missing - see rapido.conf.example"
 
-# initramfs output path
-DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
-
-# initramfs xattr name, with optional qemu parameters
-QEMU_ARGS_XATTR="user.rapido.qemu_args"
-
-# initramfs ramdisk details
-ZRAM_INITRD_SIZE="1G"
-ZRAM_INITRD_MNT="$RAPIDO_DIR/initrds"
-
-if [ -n "$CEPH_SRC" ]; then
-	# ramdisk for vstart.sh logs and data
-	ZRAM_VSTART_OUT_SIZE="1G"
-	ZRAM_VSTART_DATA_SIZE="1G"
-
+function _rt_ceph_src_globals_set {
 	if [ -f "${CEPH_SRC}/../build/CMakeCache.txt" ]; then
 		# cmake build, compiled binaries and configs are in build subdir
 		CEPH_BIN="${CEPH_SRC}/../build/bin/ceph"
@@ -46,10 +32,6 @@ if [ -n "$CEPH_SRC" ]; then
 		CEPH_RBD_LIB="${CEPH_SRC}/../build/lib/librbd.so"
 		CEPH_CONF="${CEPH_SRC}/../build/ceph.conf"
 		CEPH_KEYRING="${CEPH_SRC}/../build/keyring"
-
-		# with cmake, vstart.sh is triggered from the build dir
-		ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/../build/out"
-		ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/../build/dev"
 	else
 		# autotools build
 		CEPH_BIN="${CEPH_SRC}/ceph"
@@ -61,17 +43,16 @@ if [ -n "$CEPH_SRC" ]; then
 		CEPH_RBD_LIB="${CEPH_SRC}/.libs/librbd.so"
 		CEPH_CONF="${CEPH_SRC}/ceph.conf"
 		CEPH_KEYRING="${CEPH_SRC}/keyring"
-
-		# vstart.sh is triggered from the src dir
-		ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/out"
-		ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/dev"
 	fi
+
 	RBD_NAMER_BIN="${CEPH_SRC}/ceph-rbdnamer"
 	RBD_UDEV_RULES="${CEPH_SRC}/../udev/50-rbd.rules"
 	CEPH_UDEV_RULES="${CEPH_SRC}/../udev/95-ceph-osd.rules"
 	CEPH_DISK_SYSTEMD_SVC="${CEPH_SRC}/../systemd/ceph-disk@.service"
 	CEPH_OSD_SYSTEMD_SVC="${CEPH_SRC}/../systemd/ceph-osd@.service"
-else
+}
+
+function _rt_ceph_installed_globals_set {
 	# use installed Ceph binaries and configs
 	RBD_NAMER_BIN="/usr/bin/ceph-rbdnamer"
 	RBD_UDEV_RULES="/usr/lib/udev/rules.d/50-rbd.rules"
@@ -87,4 +68,40 @@ else
 	CEPH_RBD_LIB="/usr/lib64/librbd.so"
 	CEPH_CONF="/etc/ceph/ceph.conf"
 	CEPH_KEYRING="/etc/ceph/ceph.client.${CEPH_USER}.keyring"
-fi
+}
+
+function _rt_require_ceph {
+	if [ -n "$CEPH_SRC" ]; then
+		_rt_ceph_src_globals_set
+	else
+		_rt_ceph_installed_globals_set
+	fi
+}
+
+function _rt_require_zram_params {
+	# initramfs ramdisk details
+	ZRAM_INITRD_SIZE="1G"
+	ZRAM_INITRD_MNT="$RAPIDO_DIR/initrds"
+
+	# ramdisk for vstart.sh logs and data
+	ZRAM_VSTART_OUT_SIZE="1G"
+	ZRAM_VSTART_DATA_SIZE="1G"
+
+	if [ -n "$CEPH_SRC" ]; then
+		if [ -f "${CEPH_SRC}/../build/CMakeCache.txt" ]; then
+			# with cmake, vstart.sh is triggered from the build dir
+			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/../build/out"
+			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/../build/dev"
+		else
+			# vstart.sh is triggered from the src dir
+			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/out"
+			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/dev"
+		fi
+	fi
+}
+
+# initramfs output path
+DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
+
+# initramfs xattr name, with optional qemu parameters
+QEMU_ARGS_XATTR="user.rapido.qemu_args"

--- a/runtime.vars
+++ b/runtime.vars
@@ -40,10 +40,10 @@ if [ -n "$CEPH_SRC" ]; then
 		CEPH_BIN="${CEPH_SRC}/../build/bin/ceph"
 		CEPH_RBD_BIN="${CEPH_SRC}/../build/bin/rbd"
 		CEPH_MOUNT_BIN="${CEPH_SRC}/../build/bin/mount.ceph"
-		CEPH_RADOS_BIN="${CEPH_SRC}/rados"
+		CEPH_RADOS_BIN="${CEPH_SRC}/../build/bin/rados"
 		CEPH_FUSE_BIN="${CEPH_SRC}/../build/bin/ceph-fuse"
-		CEPH_RADOS_LIB="${CEPH_SRC}/../lib/librados.so"
-		CEPH_RBD_LIB="${CEPH_SRC}/../lib/librbd.so"
+		CEPH_RADOS_LIB="${CEPH_SRC}/../build/lib/librados.so"
+		CEPH_RBD_LIB="${CEPH_SRC}/../build/lib/librbd.so"
 		CEPH_CONF="${CEPH_SRC}/../build/ceph.conf"
 		CEPH_KEYRING="${CEPH_SRC}/../build/keyring"
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -76,6 +76,22 @@ function _rt_require_ceph {
 	else
 		_rt_ceph_installed_globals_set
 	fi
+
+	[ -f "$RBD_NAMER_BIN" ] || _fail "missing $RBD_NAMER_BIN"
+	[ -f "$RBD_UDEV_RULES" ] || _fail "missing $RBD_UDEV_RULES"
+	[ -f "$CEPH_UDEV_RULES" ] || _fail "missing $CEPH_UDEV_RULES"
+	[ -f "$CEPH_DISK_SYSTEMD_SVC" ] \
+				|| _fail "missing $CEPH_DISK_SYSTEMD_SVC"
+	[ -f "$CEPH_OSD_SYSTEMD_SVC" ] || _fail "missing $CEPH_OSD_SYSTEMD_SVC"
+	[ -f "$CEPH_BIN" ] || _fail "missing $CEPH_BIN"
+	[ -f "$CEPH_RBD_BIN" ] || _fail "missing $CEPH_RBD_BIN"
+	[ -f "$CEPH_MOUNT_BIN" ] || _fail "missing $CEPH_MOUNT_BIN"
+	[ -f "$CEPH_RADOS_BIN" ] || _fail "missing $CEPH_RADOS_BIN"
+	[ -f "$CEPH_FUSE_BIN" ] || _fail "missing $CEPH_FUSE_BIN"
+	[ -f "$CEPH_RADOS_LIB" ] || _fail "missing $CEPH_RADOS_LIB"
+	[ -f "$CEPH_RBD_LIB" ] || _fail "missing $CEPH_RBD_LIB"
+	[ -f "$CEPH_CONF" ] || _fail "missing $CEPH_CONF"
+	[ -f "$CEPH_KEYRING" ] || _fail "missing $CEPH_KEYRING"
 }
 
 function _rt_require_zram_params {
@@ -97,6 +113,11 @@ function _rt_require_zram_params {
 			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/out"
 			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/dev"
 		fi
+
+		[ -d "$ZRAM_VSTART_OUT_MNT" ] \
+					|| _fail "missing $ZRAM_VSTART_OUT_MNT"
+		[ -d "$ZRAM_VSTART_DATA_MNT" ] \
+					|| _fail "missing $ZRAM_VSTART_DATA_MNT"
 	fi
 }
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -130,6 +130,14 @@ function _rt_require_dracut_args() {
 			   --force --tmpdir $RAPIDO_DIR/initrds/ \
 			   --kver $kver"
 
+	# The optional KERNEL_INSTALL_MOD_PATH rapido.conf parameter can be used
+	# to specify where Dracut should try to pull built kernel modules from.
+	if [ -n "$KERNEL_INSTALL_MOD_PATH" ]; then
+		[ -d "$KERNEL_INSTALL_MOD_PATH" ] \
+				|| _fail "missing $KERNEL_INSTALL_MOD_PATH"
+		dracut_args="$dracut_args --kmoddir $KERNEL_INSTALL_MOD_PATH"
+	fi
+
 	DRACUT_EXTRA_ARGS="$dracut_args"
 }
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -121,6 +121,18 @@ function _rt_require_zram_params {
 	fi
 }
 
+function _rt_require_dracut_args() {
+	[ -f "${KERNEL_SRC}/include/config/kernel.release" ] \
+		|| _fail "kernel.release file missing $KERNEL_SRC"
+	local kver="$(cat ${KERNEL_SRC}/include/config/kernel.release)"
+
+	local dracut_args="--no-compress --no-hostonly --no-hostonly-cmdline \
+			   --force --tmpdir $RAPIDO_DIR/initrds/ \
+			   --kver $kver"
+
+	DRACUT_EXTRA_ARGS="$dracut_args"
+}
+
 # initramfs output path
 DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 

--- a/tools/zram_setup.sh
+++ b/tools/zram_setup.sh
@@ -17,6 +17,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
+_rt_require_zram_params
+
 set -x
 
 function _zram_setup() {


### PR DESCRIPTION
This is built atop https://github.com/ddiss/rapido/pull/7 .
Common dracut parameters are moved into a runtime.vars function, which adds a --kmoddir argument if KERNEL_INSTALL_MOD_PATH is specified in rapido.conf .