### PR TITLE
runtime.vars: fix dracut --kmoddir parameter

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -155,9 +155,10 @@ function _rt_require_dracut_args() {
 	# The optional KERNEL_INSTALL_MOD_PATH rapido.conf parameter can be used
 	# to specify where Dracut should try to pull built kernel modules from.
 	if [ -n "$KERNEL_INSTALL_MOD_PATH" ]; then
-		[ -d "$KERNEL_INSTALL_MOD_PATH" ] \
-				|| _fail "missing $KERNEL_INSTALL_MOD_PATH"
-		dracut_args="$dracut_args --kmoddir $KERNEL_INSTALL_MOD_PATH"
+		local kmoddir="$KERNEL_INSTALL_MOD_PATH/lib/modules/$kver"
+		[ -d "$kmoddir" ] \
+				|| _fail "missing $kmoddir"
+		dracut_args="$dracut_args --kmoddir $kmoddir"
 	fi
 
 	DRACUT_EXTRA_ARGS="$dracut_args"


### PR DESCRIPTION
The --kmoddir expects the directory for the correct kernel version, not
the base directory where the modules will be installed.

Signed-off-by: Luis Henriques <lhenriques@suse.com>